### PR TITLE
Ignore bundler folder in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /wagtail
 /wagtaildemo
 /.vagrant
+/.bundle
 /libs
 /Vagrantfile.local
 *.swp


### PR DESCRIPTION
Not entirely sure where it comes from, it seems to be generated when running `vagrant up`.