### PR TITLE
Update gitignore pattern for the new demo site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /wagtail
-/wagtaildemo
+/bakerydemo
 /.vagrant
 /.bundle
 /libs


### PR DESCRIPTION
Otherwise the `bakerydemo` folder is marked as untracked in this repository.