### PR TITLE
Upgrade to Ubuntu 16.04 LTS (Xenial Xerus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ A script to painlessly set up a Vagrant environment for development of Wagtail.
 
 Features
 --------
+* An Ubuntu 16.04 LTS (Xenial Xerus) base image
 * Checkouts of Wagtail, bakerydemo, django-modelcluster and Willow ready to develop against
 * Node.js / npm toolchain for front-end asset building
-* Optional packages installed (PostgreSQL, ElasticSearch, Embedly, Sphinx...)
-* Virtualenv for Python 3
+* Elasticsearch 5 installed (but disabled by default to make the VM less resource-heavy)
+* Optional packages installed (PostgreSQL, Embedly, Sphinx...)
+* Virtualenv for Python 3.5
 
 Setup
 -----

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "torchbox/wagtail"
-  config.vm.box_version = "~> 1.0"
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.box_version = "~> 20171028.0.0"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/xenial32"
   config.vm.box_version = "~> 20171028.0.0"
 
   # Disable automatic box update checking. If you disable this, then

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -4,29 +4,52 @@ WAGTAIL_ROOT=/vagrant/wagtail
 BAKERYDEMO_ROOT=/vagrant/bakerydemo
 LIBS_ROOT=/vagrant/libs
 
-VIRTUALENV_DIR=/home/vagrant/.virtualenvs/bakerydemo
+VIRTUALENV_DIR=/home/ubuntu/.virtualenvs/bakerydemo
 
 PYTHON=$VIRTUALENV_DIR/bin/python
 PIP=$VIRTUALENV_DIR/bin/pip
 
+
+# Update APT database
+apt-get update -y
+
+# useful tools
+apt-get install -y vim git curl gettext build-essential
+# Python 3
+apt-get install -y python3 python3-dev python3-pip python3-venv
+# PIL dependencies
+apt-get install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev
+# Redis and PostgreSQL
+apt-get install -y redis-server postgresql libpq-dev
+# libenchant (spellcheck library for docs)
+apt-get install -y libenchant-dev
+# Java for Elasticsearch
+apt install -y openjdk-8-jre-headless
+
+# Create pgsql superuser
+su - postgres -c "createuser -s ubuntu"
+
+pip3 install -U pip
+pip install virtualenvwrapper
+
+# Set up virtualenvwrapper in .bashrc
+cat << EOF >> /home/ubuntu/.bashrc
+export WORKON_HOME=/home/ubuntu/.virtualenvs
+export VIRTUALENVWRAPPER_PYTHON=python3
+source /usr/local/bin/virtualenvwrapper.sh
+EOF
+
+
 # bring up a PostgreSQL-enabled bakerydemo instance using the current release version of wagtail
-PROJECT_DIR=$BAKERYDEMO_ROOT USE_POSTGRESQL=1 $BAKERYDEMO_ROOT/vagrant/provision.sh bakerydemo
-
-# install system-wide developer dependencies
-apt-get update
-apt-get install -y libenchant-dev ruby2.0
-gem2.0 install scss_lint
-
-#Update pip
-su - vagrant -c "$PIP install -U pip"
+PROJECT_DIR=$BAKERYDEMO_ROOT DEV_USER=ubuntu USE_POSTGRESQL=1 $BAKERYDEMO_ROOT/vagrant/provision.sh bakerydemo
 
 # install additional dependencies (including developer-specific ones)
 # of wagtail master
 
-su - vagrant -c "cd $WAGTAIL_ROOT && $PIP install -e .[testing,docs] -U"
+su - ubuntu -c "cd $WAGTAIL_ROOT && $PIP install -e .[testing,docs] -U"
 
 # install optional packages (so that the full test suite runs)
-su - vagrant -c "$PIP install embedly elasticsearch django-sendfile"
+su - ubuntu -c "$PIP install embedly \"elasticsearch>=5.0,<6.0\" django-sendfile"
 
 # install Node.js (for front-end asset building)
 # as per instructions on https://github.com/nodesource/distributions
@@ -34,12 +57,25 @@ curl -sL https://deb.nodesource.com/setup_8.x | bash -
 apt-get install -y nodejs
 
 # set up our local checkouts of django-modelcluster and Willow
-su - vagrant -c "cd $LIBS_ROOT/django-modelcluster && $PYTHON setup.py develop"
-su - vagrant -c "cd $LIBS_ROOT/Willow && $PYTHON setup.py develop"
+su - ubuntu -c "cd $LIBS_ROOT/django-modelcluster && $PYTHON setup.py develop"
+su - ubuntu -c "cd $LIBS_ROOT/Willow && $PYTHON setup.py develop"
 
 # Install node.js tooling
 echo "Installing node.js tooling..."
-su - vagrant -c "cd $WAGTAIL_ROOT && npm install && npm run build"
+su - ubuntu -c "cd $WAGTAIL_ROOT && npm install && npm run build"
 
 # run additional migrations in wagtail master
-su - vagrant -c "$PYTHON $BAKERYDEMO_ROOT/manage.py migrate --noinput"
+su - ubuntu -c "$PYTHON $BAKERYDEMO_ROOT/manage.py migrate --noinput"
+
+# Elasticsearch (disabled by default, as it's a resource hog)
+echo "Downloading Elasticsearch..."
+wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.3.deb
+dpkg -i elasticsearch-5.3.3.deb
+rm elasticsearch-5.3.3.deb
+# reduce JVM heap size from 2g to 512m
+sed -i 's/^\(-Xm[sx]\)2g$/\1512m/g' /etc/elasticsearch/jvm.options
+# to enable:
+# systemctl enable elasticsearch
+# systemctl start elasticsearch
+
+echo "Vagrant setup complete. You can now log in with: vagrant ssh"


### PR DESCRIPTION
Mostly prompted by the desire to use versions of Python and Elasticsearch that aren't about to be deprecated...

provision.sh now starts from a totally vanilla Ubuntu base box instead of vagrant-wagtail-base. vagrant-wagtail-base was getting a bit fragmented, since it was trying to be both a bleeding-edge developer box and an approximation to Torchbox's (debian-stable-based) hosting setup. This meant that we were reliant on backports and building from source to keep things up to date - ditching that setup makes things sufficiently simpler and faster that it negates the need for a custom base image :-)