### PR TITLE
Use wagtail-2.0 branch of wagtail/bakerydemo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Features
 * Optional packages installed (PostgreSQL, ElasticSearch, Embedly, Sphinx...)
 * Virtualenv for Python 3
 
+This script currently uses a `wagtail-2.0` branch of bakerydemo to test breaking changes in Wagtail 2.0.
+
 Setup
 -----
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-git clone https://github.com/wagtail/bakerydemo.git
+# Fail if any command fails.
+set -e
+
+git clone -b wagtail-2.0 https://github.com/wagtail/bakerydemo.git
 git clone https://github.com/wagtail/wagtail.git
 mkdir -p libs
 git clone https://github.com/wagtail/django-modelcluster.git libs/django-modelcluster


### PR DESCRIPTION
This change updates this project to use a `wagtail-2.0` branch of [wagtail/bakerydemo](https://github.com/wagtail/bakerydemo) so that breaking changes in 2.0 can be easily worked on without requiring an upgrade of bakerydemo.

See https://github.com/wagtail/wagtail/issues/3918 for background.

This change also adds `set -e` to the bash script so that it aborts if any command fails.