### PR TITLE
Remove extra memory requirement for node-sass

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,8 @@ Vagrant.configure(2) do |config|
   # Provider-specific configuration for VirtualBox.
   config.vm.provider "virtualbox" do |vb|
 
-    # Building node-sass requires more than the default 512Mb of memory
-    vb.memory = 1024
+  # development requires more than the default 512Mb of memory
+  vb.memory = 1024
   end
 
   # Enable provisioning with a shell script


### PR DESCRIPTION
* native modules no longer used for sass due to adoption of `dart-sass`
* https://github.com/wagtail/wagtail/pull/6033
* https://github.com/wagtail/wagtail/commit/7eeb44ad0408cf72060f19db577de2159859cd74