### PR TITLE
Upgrade to ubuntu/focal64 - partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A script to painlessly set up a Vagrant environment for development of Wagtail.
 
 Features
 --------
-* An Ubuntu 18.04 LTS (Bionic Beaver) base image
+* An Ubuntu 20.04 LTS (Focal Fossa) base image
 * Checkouts of Wagtail, bakerydemo, django-modelcluster and Willow ready to develop against
 * Node.js / npm toolchain for front-end asset building
 * Elasticsearch 5 installed (but disabled by default to make the VM less resource-heavy)
 * Optional packages installed (PostgreSQL, Embedly, Sphinx...)
-* Virtualenv for Python 3.6
+* Virtualenv for Python 3.8
 
 Setup
 -----

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,9 +11,9 @@ Vagrant.configure(2) do |config|
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/bionic64"
-  config.vm.box_version = "~> 20190918.0.0"
+  # boxes at https://app.vagrantup.com/boxes/search.
+  config.vm.box = "ubuntu/focal64"
+  config.vm.box_version = "~> 20200814.0.0"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -31,8 +31,12 @@ Vagrant.configure(2) do |config|
   # Provider-specific configuration for VirtualBox.
   config.vm.provider "virtualbox" do |vb|
 
-  # development requires more than the default 512Mb of memory
-  vb.memory = 1024
+    # development requires more than the default 512Mb of memory
+    vb.memory = 1024
+
+    # Overcome startup timeout issue on recent boxes https://bugs.launchpad.net/cloud-images/+bug/1829625
+    vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
   end
 
   # Enable provisioning with a shell script


### PR DESCRIPTION
Upgrades to Ubuntu 20.04 and applies a workaround for startup timeout issue.

However there are still issues - at least with Ubuntu 20.04 as the host OS. Running _npm install_ inside the VM fails possibly due to Vagrant synced folders symbolic link issues but this has not been confirmed.

```
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /vagrant/wagtail/node_modules/acorn-dynamic-import/node_modules/acorn/package.json.1573126151
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/vagrant/wagtail/node_modules/acorn-dynamic-import/node_modules/acorn/package.json.1573126151'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```

Solutions that worked for me:
- Run _npm install_ on the host
- Use NFS synced folders.
- Abandon synced folders and use _unison_ for two-way file synchronisation between host and guest. The way I usually do it anyway.

Although this PR is not merge worthy in itself, it does get part way there and may save someone else some time.


