### PR TITLE
Add VSCode debugging config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Django",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/bakerydemo/manage.py",
+      "args": ["runserver", "0.0.0.0:8000"],
+      "django": true,
+      "justMyCode": false,
+      "cwd": "${workspaceFolder}/bakerydemo/",
+      "python": "python"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ vagrant ssh
 # Success!
 ```
 
+Alternatively, if you're using VSCode and have the "Remote - SSH" extension, you can connect VSCode to the vagrant VM directly. This allows for much deeper debugging. Once connected, open the `/vagrant` directory. A debug `launch.json` is included and ready to go.
+
+Once wagtail is up and running,
+
 - Visit your site at http://localhost:8000
 - The admin interface is at http://localhost:8000/admin/ - log in with `admin` / `changeme`.
 


### PR DESCRIPTION
This adds a debug config for VSCode, and adds basic instructions on how to attach VSCode to vagrant to be able to use it.

See also https://github.com/wagtail/docker-wagtail-develop/pull/24

