### PR TITLE
Vagrant development on Windows 11

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://app.vagrantup.com/boxes/search.
   config.vm.box = "ubuntu/impish64"
-  config.vm.box_version = "~> 20220123.0.0"
+  config.vm.box_version = "~> 20220319.0.1"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -24,7 +24,7 @@ apt-get update -y
 # useful tools
 apt-get install -y vim git curl gettext build-essential
 # Python 3
-apt-get install -y python3 python3-dev python3-pip python3-venv
+apt-get install -y python3 python3-dev python3-pip python3-venv python-is-python3
 # PIL dependencies
 apt-get install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev
 # Redis and PostgreSQL


### PR DESCRIPTION
Two small changes which I found necessary to get Wagtail building / running on a VirtualBox VM hosted on Windows 11

See comment on [Issue 4870](https://github.com/wagtail/wagtail/issues/4870#issuecomment-1107858886)


Update VM image version. 
Install python-is-python3