### PR TITLE
Post node-20 upgrade fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Features
 * An Ubuntu 22.04 (Jammy Jellyfish) base image
 * Checkouts of Wagtail, bakerydemo, django-modelcluster and Willow ready to develop against
 * Node.js / npm toolchain for front-end asset building
-* Elasticsearch 5 installed (but disabled by default to make the VM less resource-heavy)
 * Optional packages installed (PostgreSQL, Embedly, Sphinx...)
 * Virtualenv for Python 3.9
 
@@ -114,27 +113,6 @@ Build the documentation:
 ```sh
 cd /vagrant/wagtail/docs
 make html
-```
-
-Start Elasticsearch:
-
-```sh
-sudo service elasticsearch start
-```
-
-To enable Elasticsearch on bakerydemo, add the following to `bakerydemo/settings/local.py`:
-
-```
-WAGTAILSEARCH_BACKENDS = {
-    'default': {
-        'BACKEND': 'wagtail.search.backends.elasticsearch5',
-        'URLS': ['http://localhost:9200'],
-        'INDEX': 'wagtail',
-        'TIMEOUT': 5,
-        'OPTIONS': {},
-        'INDEX_SETTINGS': {},
-    }
-}
 ```
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |vb|
 
     # development requires more than the default 512Mb of memory
-    vb.memory = 1024
+    vb.memory = 2048
   end
 
   # Enable provisioning with a shell script

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -13,6 +13,8 @@ ELASTICSEARCH_VERSION=5.3.3
 ELASTICSEARCH_REPO=https://artifacts.elastic.co/downloads/elasticsearch
 ELASTICSEARCH_DEB="elasticsearch-${ELASTICSEARCH_VERSION}.deb"
 
+NODEJS_VERSION=20
+
 BASHRC=/home/vagrant/.bashrc
 
 # silence "dpkg-preconfigure: unable to re-open stdin" warnings
@@ -22,7 +24,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 
 # useful tools
-apt-get install -y vim git curl gettext build-essential
+apt-get install -y vim git curl gettext build-essential ca-certificates gnupg
 # Python 3
 apt-get install -y python3 python3-dev python3-pip python3-venv python-is-python3
 # PIL dependencies
@@ -87,10 +89,13 @@ su - vagrant -c "cd $WAGTAIL_ROOT && $PIP install -e .[testing,docs] -U"
 su - vagrant -c "$PIP install embedly \"elasticsearch>=5.0,<6.0\" django-sendfile"
 
 # install Node.js (for front-end asset building)
+# as per instructions on https://github.com/nodesource/distributions
 # prevent the warning "apt-key output should not be parsed"
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-# as per instructions on https://github.com/nodesource/distributions
-curl -sL https://deb.nodesource.com/setup_20.x | bash -
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODEJS_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+apt-get update
 apt-get install -y nodejs
 
 # set up our local checkouts of django-modelcluster and Willow


### PR DESCRIPTION
* Update node.js installation to follow the new recommended steps from https://github.com/nodesource/distributions#installation-instructions
* remove elasticsearch (it was outdated, resource-heavy, and most people don't need it)
* Bump memory up to 2Gb to prevent failures during npm install